### PR TITLE
Chore/split workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,9 @@
 name: CodeQL
 
 on:
+  push:
+    branches:
+      - chore/split-workflows
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches:
-      - chore/split-workflows
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          config-file: .github/codeql/codeql-config.yml
+          languages: ${{ matrix.language }}
+          source-root: src
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,9 +1,6 @@
 name: Dependency Audit
 
 on:
-  push:
-    branches:
-      - chore/split-workflows
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,6 +1,9 @@
 name: Dependency Audit
 
 on:
+  push:
+    branches:
+      - chore/split-workflows
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,29 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: npm audit (production, high+)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: npm audit (production, high+)
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,9 +1,6 @@
 name: Licensed
 
 on:
-  push:
-    branches:
-      - chore/split-workflows
   schedule:
     - cron: '0 15 * * 0,3'
   workflow_dispatch:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,6 +1,9 @@
 name: Licensed
 
 on:
+  push:
+    branches:
+      - chore/split-workflows
   schedule:
     - cron: '0 15 * * 0,3'
   workflow_dispatch:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,0 +1,56 @@
+name: Licensed
+
+on:
+  schedule:
+    - cron: '0 15 * * 0,3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  licensed:
+    name: Check Licenses
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+
+      - uses: licensee/setup-licensed@v1.3.2
+        with:
+          version: 4.x
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: Update Licenses
+        run: licensed cache
+
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: Commit Licenses
+        run: |
+          git config --local user.email "licensed-ci@users.noreply.github.com"
+          git config --local user.name "licensed-ci"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Auto-update license files"
+            git push
+          fi
+
+      - name: Check Licenses
+        run: licensed status

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '31 7 * * 3'
   workflow_dispatch:
 
 permissions:
@@ -17,7 +15,6 @@ permissions:
 jobs:
   lint:
     name: Format & Lint
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,7 +37,6 @@ jobs:
 
   test:
     name: Tests
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +56,6 @@ jobs:
 
   bundle:
     name: Bundle & Check dist
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -99,101 +94,3 @@ jobs:
         with:
           name: dist
           path: dist/
-
-  dependency-audit:
-    name: Dependency Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: npm
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: npm audit (production, high+)
-        run: npm audit --omit=dev --audit-level=high
-
-  analyze:
-    name: CodeQL Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: write
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - typescript
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          config-file: .github/codeql/codeql-config.yml
-          languages: ${{ matrix.language }}
-          source-root: src
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
-
-  licensed:
-    name: Check Licenses
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: npm
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ruby
-
-      - uses: licensee/setup-licensed@v1.3.2
-        with:
-          version: 4.x
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ github.event_name == 'workflow_dispatch' }}
-        name: Update Licenses
-        run: licensed cache
-
-      - if: ${{ github.event_name == 'workflow_dispatch' }}
-        name: Commit Licenses
-        run: |
-          git config --local user.email "licensed-ci@users.noreply.github.com"
-          git config --local user.name "licensed-ci"
-          git add .
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Auto-update license files"
-            git push
-          fi
-
-      - name: Check Licenses
-        run: licensed status


### PR DESCRIPTION
This pull request refactors our GitHub Actions workflows by moving the jobs for CodeQL analysis, dependency audit, and license checks from the main `npm-ci.yml` workflow into their own dedicated workflow files. This improves maintainability and clarity by separating concerns and ensuring each workflow runs independently on its own schedule. Additionally, unnecessary conditional checks and scheduled triggers have been removed from `npm-ci.yml`.

**Workflow separation and scheduling:**

* Created new workflow files: `.github/workflows/codeql.yml`, `.github/workflows/dependency-audit.yml`, and `.github/workflows/licensed.yml`, each with its own scheduled trigger and job definitions for CodeQL analysis, dependency auditing, and license checking respectively. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R1-R38) [[2]](diffhunk://#diff-781c7519f37eabca5a2dea4e7a2fb39ad94e7b84f0cc5559b17dc44dba7c82e6R1-R29) [[3]](diffhunk://#diff-28c4d319df05939745eddb957f33e186df1d9d2eb8db6ef558fbddfb6d43db4cR1-R56)

**Cleanup in `npm-ci.yml`:**

* Removed the scheduled trigger and jobs for dependency audit, CodeQL analysis, and license checks from `npm-ci.yml`, so it now only handles linting, testing, and bundling. [[1]](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L10-L11) [[2]](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L102-L199)
* Eliminated unnecessary conditional checks (`if: github.event_name != 'schedule'`) from job definitions in `npm-ci.yml`, since scheduled jobs have been moved. [[1]](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L20) [[2]](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L43) [[3]](diffhunk://#diff-0886856b99a59ca164f5a8c53d04d50498d730fa38cac7677868ecfec21bba34L63)